### PR TITLE
Fix the "&" symbol

### DIFF
--- a/src/jokes.json
+++ b/src/jokes.json
@@ -784,7 +784,7 @@
 	},
 	"186": {
 		"q": "Want to know the biggest lie in the universe?",
-		"a": "I have read and agree to the Terms & Conditions",
+		"a": "I have read and agree to the Terms \\& Conditions",
 		"form": "qa"
 	},
 	"187": {


### PR DESCRIPTION
Once upon a time, it'll error anyway because of the unescaped "&" symbol in `jokes.json`.

So I'm opening this pull request.